### PR TITLE
Adding a way to abort requests

### DIFF
--- a/src/atomic.js
+++ b/src/atomic.js
@@ -63,6 +63,13 @@
       always: function (callback) {
         methods.always = callback;
         return atomXHR;
+      },
+      abort: function () {
+        // only if request is still not loaded, we should abort it
+        if (request && request.readyState !== 4) {
+          request.onreadystatechange = null;
+          request.abort();
+        }
       }
     };
 

--- a/test/atomic-spec.js
+++ b/test/atomic-spec.js
@@ -47,6 +47,27 @@ describe('atomic', function () {
 
   });
 
+  describe('abort', function() {
+
+    it('should be able to abort the request', function(){
+      var result = 0;
+      var req = atomic.get('https://freegeoip.net')
+        .always(function(data, xhr) {
+          result = 3;
+        })
+        .success(function(data, xhr) {
+          result = 1;
+        })
+        .error(function(data, xhr) {
+          result = 2;
+        });
+
+      req.abort();
+      expect(result).toBe(0);
+    });
+
+  })
+
   describe('always', function() {
 
     it('should be called last after success or error', function(done) {
@@ -55,7 +76,7 @@ describe('atomic', function () {
           result = 3;
         })
         .success(function(data, xhr) {
-          result  = 1;
+          result = 1;
         })
         .error(function(data, xhr) {
           result  = 2;


### PR DESCRIPTION
Fixing issue #20 
New `abort` function attached to the request in order to be able to
abort requests.
Added tests for new functionality.